### PR TITLE
Fix district with the same name but having different city

### DIFF
--- a/includes/classes/class-woongkir-shipping-method.php
+++ b/includes/classes/class-woongkir-shipping-method.php
@@ -1054,6 +1054,7 @@ class Woongkir_Shipping_Method extends WC_Shipping_Method {
 				$origin_location_address_2 = woongkir_get_json_data(
 					'address_2',
 					array(
+						'city' => $this->get_option( 'origin_location_city' ),
 						'value' => $this->get_option( 'origin_location_address_2' ),
 					)
 				);

--- a/includes/classes/class-woongkir-shipping-method.php
+++ b/includes/classes/class-woongkir-shipping-method.php
@@ -1054,7 +1054,7 @@ class Woongkir_Shipping_Method extends WC_Shipping_Method {
 				$origin_location_address_2 = woongkir_get_json_data(
 					'address_2',
 					array(
-						'city' => $this->get_option( 'origin_location_city' ),
+						'city'  => $this->get_option( 'origin_location_city' ),
 						'value' => $this->get_option( 'origin_location_address_2' ),
 					)
 				);


### PR DESCRIPTION
This will fix the district origin when there are same district name but having different city. Before this fix, the origin district returns the first result from `array_intersect_assoc` whether it was from the right city or not.